### PR TITLE
Switch to contextvars instead of threadlocal for logging.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,3 @@
 colorama~=0.4.3
 more-itertools~=8.7.0
-structlog~=20.2.0
+structlog~=22.1.0


### PR DESCRIPTION
Deactivate thread local logging context.
Switch to contextvars to store context aware global state instead, as the old method is deprecated.
Added a typeless (to avoid requires on fastapi and such) middleware for clearing the context log in an API.
Bumped structlog.