### PR TITLE
Bump redis-py from 4.4 to 4.5

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,9 +1,9 @@
 [bumpversion]
-current_version = 1.4.7
+current_version = 1.4.8
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?
-serialize =
+serialize = 
 	{major}.{minor}.{patch}-{release}{build}
 	{major}.{minor}.{patch}
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,7 @@ repos:
     rev: v4.4.0
     hooks:
       - id: trailing-whitespace
+        exclude: .bumpversion.cfg
       - id: end-of-file-fixer
       - id: check-docstring-first
       - id: check-json

--- a/nwastdlib/__init__.py
+++ b/nwastdlib/__init__.py
@@ -13,7 +13,7 @@
 #
 """The NWA-stdlib module."""
 
-__version__ = "1.4.7"
+__version__ = "1.4.8"
 
 from nwastdlib.f import const, identity
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,8 @@ classifiers = [
 requires = [
     "structlog~=22.1.0",
     "colorama~=0.4.3",
-    "redis~=4.4.2"
+    "redis>=4.5.3, <4.6.0",  # Required for anyio 3.7 https://github.com/redis/redis-py/issues/2633
+    "anyio>=3.7.0",
 ]
 description-file = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
anyio 3.7 was released recently (May 27th) and is incompatible with redis-py 4.4. Long story here: https://github.com/redis/redis-py/issues/2633

Solution is to bump redis-py to 4.5.3 or higher.