### PR TITLE
Add VlanRangesValidator back as composed type

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.5.1
+current_version = 1.5.2
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/nwastdlib/__init__.py
+++ b/nwastdlib/__init__.py
@@ -13,7 +13,7 @@
 #
 """The NWA-stdlib module."""
 
-__version__ = "1.5.1"
+__version__ = "1.5.2"
 
 from nwastdlib.f import const, identity
 

--- a/nwastdlib/vlans.py
+++ b/nwastdlib/vlans.py
@@ -19,11 +19,9 @@ import operator
 from collections import abc
 from collections.abc import Iterable, Iterator, Sequence
 from functools import reduce, total_ordering
-from typing import AbstractSet, Any, Optional, Union, cast
+from typing import AbstractSet, Annotated, Any, Optional, Union, cast
 
-from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler
-from pydantic.json_schema import JsonSchemaValue
-from pydantic_core import CoreSchema, core_schema
+from pydantic import AfterValidator, Field, PlainSerializer
 
 
 def to_ranges(i: Iterable[int]) -> Iterable[range]:
@@ -252,36 +250,37 @@ class VlanRanges(abc.Set):
         except ValueError:
             return False
 
-    @classmethod
-    def __get_pydantic_core_schema__(cls, _source_type: Any, _handler: GetCoreSchemaHandler) -> CoreSchema:
-        return core_schema.no_info_after_validator_function(
-            cls._validate,
-            core_schema.str_schema(),
-            serialization=core_schema.plain_serializer_function_ser_schema(
-                cls._serialize,
-                info_arg=False,
-                return_schema=core_schema.str_schema(),
-            ),
-        )
 
-    @classmethod
-    def __get_pydantic_json_schema__(cls, core_schema_: CoreSchema, handler: GetJsonSchemaHandler) -> JsonSchemaValue:
-        json_schema = handler(core_schema_)
-        json_schema_resolved = handler.resolve_ref_schema(json_schema)
-        schema_override = {
-            "type": "string",
-            "format": "vlanrange",
-            "pattern": "^([1-4][0-9]{0,3}(-[1-4][0-9]{0,3})?,?)+$",
-            "examples": ["345", "20-23,45,50-100"],
-        }
-        return json_schema_resolved | schema_override
+def _serialize_vlanranges(value: VlanRanges) -> str:
+    return str(value)
 
-    @staticmethod
-    def _validate(input_value: Union[str, VlanRanges]) -> VlanRanges:
-        if isinstance(input_value, VlanRanges):
-            return input_value
-        return VlanRanges(input_value)
 
-    @staticmethod
-    def _serialize(value: VlanRanges) -> str:
-        return str(value)
+def _validate_vlanranges(input_value: Union[str, VlanRanges]) -> VlanRanges:
+    if isinstance(input_value, VlanRanges):
+        return input_value
+    return VlanRanges(input_value)
+
+
+def vlan_ranges_validator(json_schema_extra: dict | None = None) -> Any:
+    """Create a VlanRanges type annotated with validation.
+
+    Args:
+        json_schema_extra: schema to add to the standard vlanranges validator schema
+    """
+    json_schema_extra = {
+        "type": "string",
+        "format": "vlanrange",
+        "pattern": "^([1-4][0-9]{0,3}(-[1-4][0-9]{0,3})?,?)+$",
+        "examples": ["345", "20-23,45,50-100"],
+    } | (json_schema_extra or {})
+
+    return Annotated[
+        str,
+        VlanRanges,
+        AfterValidator(_validate_vlanranges),
+        PlainSerializer(_serialize_vlanranges, when_used="json"),
+        Field(json_schema_extra=json_schema_extra),
+    ]
+
+
+VlanRangesValidator = vlan_ranges_validator()

--- a/nwastdlib/vlans.py
+++ b/nwastdlib/vlans.py
@@ -255,7 +255,7 @@ def _serialize_vlanranges(value: VlanRanges) -> str:
     return str(value)
 
 
-def _validate_vlanranges(input_value: Union[str, VlanRanges]) -> VlanRanges:
+def _validate_vlanranges(input_value: Any) -> VlanRanges:
     if isinstance(input_value, VlanRanges):
         return input_value
     return VlanRanges(input_value)
@@ -275,7 +275,7 @@ def vlan_ranges_validator(json_schema_extra: dict | None = None) -> Any:
     } | (json_schema_extra or {})
 
     return Annotated[
-        str,
+        Any,
         VlanRanges,
         AfterValidator(_validate_vlanranges),
         PlainSerializer(_serialize_vlanranges, when_used="json"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ test = [
     "anyio",
     "black",
     "fakeredis",
-    "mypy",
+    "mypy==1.6.1",
     "mypy_extensions",
     "pytest",
     "pytest-asyncio",

--- a/tests/test_vlans.py
+++ b/tests/test_vlans.py
@@ -1,8 +1,7 @@
 import pytest
 from pydantic import BaseModel
-from pydantic.dataclasses import dataclass
 
-from nwastdlib.vlans import VlanRanges
+from nwastdlib.vlans import VlanRanges, VlanRangesValidator
 
 
 def test_vlan_ranges_instantiation():
@@ -201,19 +200,17 @@ def test_vlan_ranges_validations(value):
         VlanRanges(value)
 
 
-def test_vlan_ranges_dataclass_validations_ok():
-    @dataclass
-    class TestVlanRanges:
-        vlanrange: VlanRanges  # type: ignore
+def test_vlan_ranges_basemodel_validations_ok():
+    class TestVlanRanges(BaseModel):
+        vlanrange: VlanRangesValidator
 
     assert TestVlanRanges(vlanrange="12").vlanrange == VlanRanges(12)
 
 
 @pytest.mark.parametrize("value", ["-30", "bla", "5000"])  # Negative values, however, are an error
-def test_vlan_ranges_dataclass_validations_nok(value):
-    @dataclass
-    class TestVlanRanges:
-        vlanrange: VlanRanges  # type: ignore
+def test_vlan_ranges_basemodel_validations_nok(value):
+    class TestVlanRanges(BaseModel):
+        vlanrange: VlanRangesValidator
 
     with pytest.raises(ValueError):
         TestVlanRanges(vlanrange=value)
@@ -227,10 +224,10 @@ def test_vlan_ranges_schema_generation(vrange, expectedlist):
     """Test that schema generation works."""
 
     class MyModel(BaseModel):
-        vlanranges: VlanRanges  # type: ignore[annotation-unchecked]
+        vlanranges: VlanRangesValidator
 
     model = MyModel(vlanranges=f"{vrange}")
-    assert model.model_dump() == {"vlanranges": f"{vrange}"}
+    assert isinstance(model.model_dump()["vlanranges"], VlanRanges)
     assert model.model_dump_json() == '{"vlanranges":"%s"}' % (vrange,)
     assert model.model_json_schema() == {
         "properties": {


### PR DESCRIPTION
* Adds `VlanRangesValidator` back as a composed type
* Use `vlan_ranges_validator(...)` to create a validator with extra json schema attributes
* Remove pydantic hooks from `VlanRanges`
* Bump version to 1.5.2