### PR TITLE
Fix schema for vlan_ranges_validator

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.5.2
+current_version = 1.5.3
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/nwastdlib/__init__.py
+++ b/nwastdlib/__init__.py
@@ -13,7 +13,7 @@
 #
 """The NWA-stdlib module."""
 
-__version__ = "1.5.2"
+__version__ = "1.5.3"
 
 from nwastdlib.f import const, identity
 

--- a/nwastdlib/debugging.py
+++ b/nwastdlib/debugging.py
@@ -25,7 +25,7 @@ def start_debugger() -> None:
     if nwa_settings.DEBUG_VSCODE:
         import debugpy
 
-        debugpy_kwargs = ("127.0.0.1", 5678)
+        debugpy_kwargs = ("127.0.0.1", nwa_settings.DEBUG_VSCODE_PORT)
         logger.info("Starting debugpy", debugpy_kwargs=debugpy_kwargs)
         debugpy.listen(debugpy_kwargs)
         logger.info("Waiting for debug client to connect")
@@ -35,7 +35,8 @@ def start_debugger() -> None:
         # trick to get around debug-statements pre-commit error: pydevd_pycharm imported
         pydevd_pycharm = __import__("pydevd_pycharm")
 
-        pydevd_kwargs = {"host": "127.0.0.1", "port": 12345, "stdoutToServer": True, "stderrToServer": True}
+        port = nwa_settings.DEBUG_PYCHARM_PORT
+        pydevd_kwargs = {"host": "127.0.0.1", "port": port, "stdoutToServer": True, "stderrToServer": True}
         logger.info("Connecting to pydevd server (choose 'Resume Program' in PyCharm)", pydevd_kwargs=pydevd_kwargs)
         pydevd_pycharm.settrace(**pydevd_kwargs)
         logger.info("Connected to pydevd server")

--- a/nwastdlib/settings.py
+++ b/nwastdlib/settings.py
@@ -22,7 +22,9 @@ class NwaSettings(BaseSettings):
     """Common settings for applications depending on nwa-stdlib."""
 
     DEBUG_VSCODE: bool = False
+    DEBUG_VSCODE_PORT: int = 5678
     DEBUG_PYCHARM: bool = False
+    DEBUG_PYCHARM_PORT: int = 12345
 
 
 nwa_settings = NwaSettings()

--- a/nwastdlib/vlans.py
+++ b/nwastdlib/vlans.py
@@ -270,7 +270,7 @@ def vlan_ranges_validator(json_schema_extra: dict | None = None) -> Any:
     """
     json_schema_extra = {
         "type": "string",
-        "format": "vlanrange",
+        "format": "vlan",
         "pattern": "^([1-4][0-9]{0,3}(-[1-4][0-9]{0,3})?,?)+$",
         "examples": ["345", "20-23,45,50-100"],
     } | (json_schema_extra or {})

--- a/nwastdlib/vlans.py
+++ b/nwastdlib/vlans.py
@@ -275,10 +275,8 @@ def vlan_ranges_validator(json_schema_extra: dict | None = None) -> Any:
         "examples": ["345", "20-23,45,50-100"],
     } | (json_schema_extra or {})
 
-    # The type origin cannot be 'Any', this causes errors when using the type in strawberry-graphql.
-    # Instead we define a union with all possible types (including VlanRanges) and tell Pydantic to use the Any schema.
     return Annotated[
-        Union[Sequence[Sequence[int]], Sequence[int], int, VlanRanges, str],
+        VlanRanges,
         GetPydanticSchema(
             lambda tp, handler: core_schema.no_info_after_validator_function(
                 _validate_vlanranges, core_schema.any_schema()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,10 +31,12 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
 ]
 requires = [
-    "structlog~=22.1.0",
-    "colorama~=0.4.3",
-    "redis>=4.6, <4.7.0",
     "anyio>=3.7.0",
+    "colorama~=0.4.3",
+    "pydantic>=2.4.0",
+    "pydantic_settings",
+    "redis>=4.6, <4.7.0",
+    "structlog~=22.1.0",
 ]
 description-file = "README.md"
 requires-python = ">=3.9"
@@ -51,7 +53,6 @@ test = [
     "mypy_extensions",
     "pytest",
     "pytest-asyncio",
-    "pydantic",
     "redis",
     "ruff",
 ]

--- a/tests/test_vlans.py
+++ b/tests/test_vlans.py
@@ -234,7 +234,7 @@ def test_vlan_ranges_schema_generation(vrange, expectedlist):
             "vlanranges": {
                 "title": "Vlanranges",
                 "type": "string",
-                "format": "vlanrange",
+                "format": "vlan",
                 "pattern": "^([1-4][0-9]{0,3}(-[1-4][0-9]{0,3})?,?)+$",
                 "examples": ["345", "20-23,45,50-100"],
             },

--- a/tests/test_vlans.py
+++ b/tests/test_vlans.py
@@ -244,3 +244,18 @@ def test_vlan_ranges_schema_generation(vrange, expectedlist):
         "type": "object",
     }
     assert list(model.vlanranges) == expectedlist
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        1,
+        "1",
+        VlanRanges(1),
+    ],
+)
+def test_vlan_ranges_validator(value):
+    class MyModel(BaseModel):
+        vr: VlanRangesValidator
+
+    assert isinstance(MyModel(vr=value).vr, VlanRanges)


### PR DESCRIPTION
* Pydantic schema fixes to `vlan_ranges_validator`
* Make remote debugger ports configurable with env vars `DEBUG_VSCODE_PORT` and `DEBUG_PYCHARM_PORT`