### PR TITLE
Use stdout and local time for logging

### DIFF
--- a/nwastdlib/logging.py
+++ b/nwastdlib/logging.py
@@ -13,6 +13,7 @@
 
 import logging.config
 import os
+import sys
 from typing import Any, Union
 
 import structlog
@@ -23,7 +24,7 @@ pre_chain = [
     # is not from structlog.
     structlog.stdlib.add_log_level,
     structlog.stdlib.add_logger_name,
-    structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M:%S"),
+    structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M:%S", utc=False),
     structlog.stdlib.PositionalArgumentsFormatter(),
     structlog.processors.StackInfoRenderer(),
     structlog.processors.format_exc_info,
@@ -54,11 +55,11 @@ logconfig_dict = {
         },
     },
     "handlers": {
-        "default": {"class": "logging.StreamHandler", "formatter": LOG_OUTPUT},
+        "default": {"class": "logging.StreamHandler", "stream": sys.stdout, "formatter": LOG_OUTPUT},
         # These handlers are needed by gunicorn
-        "error_console": {"class": "logging.StreamHandler", "formatter": LOG_OUTPUT},
-        "console": {"class": "logging.StreamHandler", "formatter": LOG_OUTPUT},
-        "gunicorn.error": {"class": "logging.StreamHandler", "formatter": LOG_OUTPUT},
+        "error_console": {"class": "logging.StreamHandler", "stream": sys.stdout, "formatter": LOG_OUTPUT},
+        "console": {"class": "logging.StreamHandler", "stream": sys.stdout, "formatter": LOG_OUTPUT},
+        "gunicorn.error": {"class": "logging.StreamHandler", "stream": sys.stdout, "formatter": LOG_OUTPUT},
     },
 }
 


### PR DESCRIPTION
Structlog defaults to writing logs to `stdout` and writing timestamps in local time. IMHO `initialise_logging()` should not change these defaults.

It is very confusing when apps like [orchestrator](https://github.com/workfloworchestrator/orchestrator-core/blob/4a3e438bfed77e6db8b2e06f3d7a9ae8e4b3ada6/orchestrator/app.py#L117) switch logging formats midway during initialisation. 

```python
import structlog
from nwastdlib.logging import initialise_logging

logger = structlog.get_logger(__name__)
logger.info("Goes to stdout with timestamp in local time")
initialise_logging()
logger.info("Goes to stderr with timestamp in UTC")
```