### PR TITLE
Fix VlanRange json schema regex

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.8.0
+current_version = 1.8.1
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/nwastdlib/__init__.py
+++ b/nwastdlib/__init__.py
@@ -13,7 +13,7 @@
 #
 """The NWA-stdlib module."""
 
-__version__ = "1.8.0"
+__version__ = "1.8.1"
 
 from nwastdlib.f import const, identity
 

--- a/nwastdlib/vlans.py
+++ b/nwastdlib/vlans.py
@@ -25,6 +25,8 @@ from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler
 from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import CoreSchema, SchemaSerializer, core_schema
 
+VLAN_RANGE_JSON_SCHEMA_REGEX = r"^(?:([1-9]|[1-9]\d{1,2}|[1-4]\d{3})(?:-(?:[1-9]|[1-9]\d{1,2}|[1-4]\d{3}))?)$"
+
 
 def to_ranges(i: Iterable[int]) -> Iterable[range]:
     """Convert a sorted iterable of ints to an iterable of range objects.
@@ -277,7 +279,7 @@ class VlanRanges(abc.Set):
         schema_override = {
             "type": "string",
             "format": "vlan",
-            "pattern": "^([1-4][0-9]{0,3}(-[1-4][0-9]{0,3})?,?)+$",
+            "pattern": VLAN_RANGE_JSON_SCHEMA_REGEX,
             "examples": ["345", "20-23,45,50-100"],
         }
         return json_schema_resolved | schema_override

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ test = [
 ]
 dev = [
     "bumpversion",
+    "jsonschema",
     "pre-commit",
     "types-redis"
 ]


### PR DESCRIPTION
* Fix the JSON schema `pattern` for the VlanRange type so that it correctly allows/rejects vlans or vlan ranges
* Added unittests for boundary values
* Bump version to 1.8.1