### PR TITLE
Mask internal server error to something generic

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.8.1
+current_version = 1.8.2
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/nwastdlib/__init__.py
+++ b/nwastdlib/__init__.py
@@ -13,7 +13,7 @@
 #
 """The NWA-stdlib module."""
 
-__version__ = "1.8.1"
+__version__ = "1.8.2"
 
 from nwastdlib.f import const, identity
 

--- a/nwastdlib/graphql/extensions/error_handler_extension.py
+++ b/nwastdlib/graphql/extensions/error_handler_extension.py
@@ -101,7 +101,7 @@ def _process(error: GraphQLError, to_error_type: Callable[[Exception | None], Er
     if not _has_extension(error, EXTENSION_ERROR_TYPE):
         _add_extension(error, EXTENSION_ERROR_TYPE, str(to_error_type(exc)))
 
-    if error_type == ErrorType.INTERNAL_ERROR and not (nwa_settings.DEBUG_PYCHARM or nwa_settings.DEBUG_PYCHARM):
+    if error_type == ErrorType.INTERNAL_ERROR and not nwa_settings.DEBUG:
         error.message = "Internal Server Error"
 
     return error

--- a/nwastdlib/graphql/extensions/error_handler_extension.py
+++ b/nwastdlib/graphql/extensions/error_handler_extension.py
@@ -22,6 +22,8 @@ from httpx import HTTPStatusError, Response
 from strawberry.extensions import SchemaExtension
 from strawberry.types import ExecutionContext, Info
 
+from nwastdlib.settings import nwa_settings
+
 logger = structlog.stdlib.get_logger(__name__)
 
 EXTENSION_ERROR_TYPE = "error_type"
@@ -93,10 +95,15 @@ def _add_extension(error: GraphQLError, key: str, value: Any) -> None:
 
 def _process(error: GraphQLError, to_error_type: Callable[[Exception | None], ErrorType]) -> GraphQLError:
     exc = error.original_error
+    error_type = to_error_type(exc)
     if isinstance(exc, HTTPStatusError):
         _add_extension(error, EXTENSION_HTTP_STATUS_CODE, {f"{exc.request.url}": exc.response.status_code})
     if not _has_extension(error, EXTENSION_ERROR_TYPE):
         _add_extension(error, EXTENSION_ERROR_TYPE, str(to_error_type(exc)))
+
+    if error_type == ErrorType.INTERNAL_ERROR and not (nwa_settings.DEBUG_PYCHARM or nwa_settings.DEBUG_PYCHARM):
+        error.message = "Internal Server Error"
+
     return error
 
 

--- a/nwastdlib/settings.py
+++ b/nwastdlib/settings.py
@@ -21,6 +21,7 @@ else:
 class NwaSettings(BaseSettings):
     """Common settings for applications depending on nwa-stdlib."""
 
+    DEBUG: bool = False
     DEBUG_VSCODE: bool = False
     DEBUG_VSCODE_PORT: int = 5678
     DEBUG_PYCHARM: bool = False

--- a/tests/graphql/test_error_handler_extension.py
+++ b/tests/graphql/test_error_handler_extension.py
@@ -51,7 +51,7 @@ async def test_error_handler_extension_no_errors():
 @pytest.mark.parametrize(
     "exception_class, message, error_type",
     [
-        (ValueError, "There was a value error", ErrorType.INTERNAL_ERROR),
+        (ValueError, "Internal Server Error", ErrorType.INTERNAL_ERROR),
         (PermissionError, "There was a permission error", ErrorType.NOT_AUTHORIZED),
     ],
 )


### PR DESCRIPTION
- does not mask when `nwa_settings.DEBUG` is true.

related: https://github.com/workfloworchestrator/orchestrator-core/issues/774