### PR TITLE
Add support for Python 3.13, update syntax to Python>=3.11, update readme

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.8.3
+current_version = 1.9.0
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/.github/workflows/test-package.yaml
+++ b/.github/workflows/test-package.yaml
@@ -27,15 +27,13 @@ jobs:
         python -m pip install --upgrade pip
         pip install flit
         flit install --deps develop --symlink
-    - name: Ruff
-      run: ruff check .
-    - name: Black
-      run: black . --check
     - name: Mypy
       run: mypy .
     - name: License headers
       run: |
-        apache-license-check --copyright "2019-`date +%Y` SURF" oauth2_lib
+        apache-license-check --copyright "2019-`date +%Y` SURF" nwastdlib
+    - name: Run pre-commit hooks
+      uses: pre-commit/action@v3.0.1
     - name: Test with pytest
       run: pytest --cov-branch --cov=nwastdlib --cov-report=xml --ignore=tests --ignore=benchmarks
     - name: "Upload coverage to Codecov"

--- a/.github/workflows/test-package.yaml
+++ b/.github/workflows/test-package.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
       fail-fast: false
 
     steps:

--- a/.github/workflows/test-package.yaml
+++ b/.github/workflows/test-package.yaml
@@ -33,6 +33,9 @@ jobs:
       run: black . --check
     - name: Mypy
       run: mypy .
+    - name: License headers
+      run: |
+        apache-license-check --copyright "2019-`date +%Y` SURF" oauth2_lib
     - name: Test with pytest
       run: pytest --cov-branch --cov=nwastdlib --cov-report=xml --ignore=tests --ignore=benchmarks
     - name: "Upload coverage to Codecov"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,12 @@ repos:
       - id: debug-statements
       - id: requirements-txt-fixer
       - id: detect-private-key
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.8.4
+    hooks:
+      - id: ruff
+        args: [ --fix, --exit-non-zero-on-fix, --show-fixes ]
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,6 @@ repos:
     rev: 24.10.0
     hooks:
       - id: black
-        language_version: python3.11
   - repo: https://github.com/asottile/blacken-docs
     rev: 1.19.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,24 +1,24 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.2.2
+    rev: v3.19.1
     hooks:
       - id: pyupgrade
         exclude: tests
         args:
-         - --py39-plus
+         - --py311-plus
          - --keep-runtime-typing
   - repo: https://github.com/psf/black
-    rev: 23.10.1
+    rev: 24.10.0
     hooks:
       - id: black
-        language_version: python3.9
+        language_version: python3.11
   - repo: https://github.com/asottile/blacken-docs
-    rev: 1.16.0
+    rev: 1.19.1
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black==22.1.0]
+        additional_dependencies: [black==24.10.0]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
         exclude: .bumpversion.cfg
@@ -38,6 +38,6 @@ repos:
       - id: python-check-mock-methods
       - id: rst-backticks
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.9.0.6
+    rev: v0.10.0.1
     hooks:
       - id: shellcheck

--- a/README.md
+++ b/README.md
@@ -4,33 +4,78 @@
 [![Supported python versions](https://img.shields.io/pypi/pyversions/nwa-stdlib.svg?color=%2334D058)](https://pypi.org/project/nwa-stdlib)
 [![codecov](https://codecov.io/github/workfloworchestrator/nwa-stdlib/graph/badge.svg?token=9XWVHKKF06)](https://codecov.io/github/workfloworchestrator/nwa-stdlib)
 
-This library contains the functions and utilities that are shared by most
-Network Automation projects built at SURF.
+This library contains the functions and utilities that are shared by most Network Automation projects built at SURF.
 
-## Getting started
+## Installation
 
-If you want to use a virtual environment first create the environment:
+To install the package from PyPI:
+
+```bash
+pip install nwa-stdlib
+```
+
+## Development
+
+### Virtual Environment
+
+Steps to setup a virtual environment.
+
+#### Step 1:
+
+Create and activate a python3 virtualenv.
+
+#### Step 2:
+
+Install flit to enable you to develop on this repository:
 
 ```bash
 pip install flit
 ```
-And then run the following commands:
 
-If you want to enhance or develop bug fixes for `nwastdlib` it's easiest to run the following commands:
+#### Step 3:
+
+To install all development dependencies:
+
 ```bash
-flit install --deps develop --symlink
+flit install --deps develop
 ```
 
-## Development
+All steps combined into 1 command:
+
+```bash
+python -m venv .venv && source .venv/bin/activate && pip install -U pip && pip install flit && flit install --deps develop
+```
+
+### Unit tests
+
+Activate the virtualenv and run the unit tests with:
+
+```bash
+pytest
+```
+
+### Pre-commit
+
+This project uses [pre-commit](https://pre-commit.com/) to automatically run a number of checks before making a git commit.
+The same checks will be performed in the CI pipeline so this can save you some time.
+
+First ensure you have pre-commit installed.
+It is recommended to install it outside the virtualenv.
+On Linux and Mac, pre-commit is available in most package managers. Alternatively you can install it globally with [pipx](https://github.com/pypa/pipx).
+
+Once pre-commit is installed, go into the project root and enable it:
+```bash
+pre-commit install
+```
+
+This should output `pre-commit installed at .git/hooks/pre-commit`. The next time you run `git commit` the pre-commit hooks will validate your changes.
+
+### Bump version
+
 Depending on the feature type, run bumpversion (patch|minor|major) to increment the version you are working on. For
 example to update the increment the patch version use
 ```bash
 bumpversion patch
-```
-
-## To run tests
-```
-pytest
 ```
 
 ## Supported Python versions

--- a/nwastdlib/__init__.py
+++ b/nwastdlib/__init__.py
@@ -1,15 +1,15 @@
-#  Copyright 2019 SURF.
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
+# Copyright 2019-2025 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#          http://www.apache.org/licenses/LICENSE-2.0
+#    http://www.apache.org/licenses/LICENSE-2.0
 #
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 """The NWA-stdlib module."""
 

--- a/nwastdlib/__init__.py
+++ b/nwastdlib/__init__.py
@@ -13,7 +13,7 @@
 #
 """The NWA-stdlib module."""
 
-__version__ = "1.8.3"
+__version__ = "1.9.0"
 
 from nwastdlib.f import const, identity
 

--- a/nwastdlib/asyncio.py
+++ b/nwastdlib/asyncio.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 SURF.
+# Copyright 2019-2025 SURF.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/nwastdlib/asyncio.py
+++ b/nwastdlib/asyncio.py
@@ -45,7 +45,7 @@ else:
 
         """
 
-        def make_args(func_args: Union[Iterable, object]) -> Iterable:
+        def make_args(func_args: Iterable | object) -> Iterable:
             # When one argument is passed, wrap it in a list so run_sync can unpack it again
             if not isinstance(func_args, (tuple, list, set)):
                 return [func_args]

--- a/nwastdlib/asyncio.py
+++ b/nwastdlib/asyncio.py
@@ -13,7 +13,7 @@
 import asyncio
 import warnings
 from collections.abc import Awaitable, Callable, Iterable
-from typing import TypeVar, Union
+from typing import TypeVar
 
 A = TypeVar("A")
 R = TypeVar("R")
@@ -29,7 +29,7 @@ else:
         args: Iterable[A],
         limit: int = 5,
         return_exceptions: bool = False,
-    ) -> list[R]:
+    ) -> list[R | BaseException]:
         """Run function in thread for each args, using asyncio.gather() with limited concurrency.
 
         Example:
@@ -60,7 +60,7 @@ async def gather_nice(
     coros: Iterable[Awaitable[R]],
     limit: int = 5,
     return_exceptions: bool = False,
-) -> Iterable[R]:
+) -> Iterable[R | BaseException]:
     """Run coroutines in asyncio.gather() with limited concurrency.
 
     Example:

--- a/nwastdlib/asyncio_cache.py
+++ b/nwastdlib/asyncio_cache.py
@@ -41,11 +41,11 @@ class DefaultSerializer:
 
     @staticmethod
     def deserialize(data: Any) -> Any:
-        return pickle.loads(data)  # noqa: S403
+        return pickle.loads(data)  # noqa: S301
 
     @staticmethod
     def serialize(data: bytes | bytearray | str) -> Any:
-        return pickle.dumps(data)  # noqa: S403
+        return pickle.dumps(data)
 
 
 def _deserialize(data: Any, serializer: SerializerProtocol) -> Any:

--- a/nwastdlib/asyncio_cache.py
+++ b/nwastdlib/asyncio_cache.py
@@ -1,15 +1,15 @@
-#  Copyright 2019-2024 SURF.
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
+# Copyright 2019-2025 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#          http://www.apache.org/licenses/LICENSE-2.0
+#    http://www.apache.org/licenses/LICENSE-2.0
 #
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 import hashlib
 import hmac

--- a/nwastdlib/asyncio_cache.py
+++ b/nwastdlib/asyncio_cache.py
@@ -13,10 +13,11 @@
 #
 import hashlib
 import hmac
-import pickle  # noqa S403
+import pickle  # noqa: S403
 import sys
+from collections.abc import Callable
 from functools import wraps
-from typing import Any, Callable, Protocol, Union, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 import structlog
 from redis.asyncio import Redis as AIORedis
@@ -40,11 +41,11 @@ class DefaultSerializer:
 
     @staticmethod
     def deserialize(data: Any) -> Any:
-        return pickle.loads(data)  # noqa S403
+        return pickle.loads(data)  # noqa: S403
 
     @staticmethod
-    def serialize(data: Union[bytes, bytearray, str]) -> Any:
-        return pickle.dumps(data)  # noqa S403
+    def serialize(data: bytes | bytearray | str) -> Any:
+        return pickle.dumps(data)  # noqa: S403
 
 
 def _deserialize(data: Any, serializer: SerializerProtocol) -> Any:
@@ -58,7 +59,7 @@ def _deserialize(data: Any, serializer: SerializerProtocol) -> Any:
     return data
 
 
-def get_hmac_checksum(secret: str, message: Union[bytes, bytearray, str]) -> str:
+def get_hmac_checksum(secret: str, message: bytes | bytearray | str) -> str:
     if isinstance(message, str):
         message = message.encode()
     h = hmac.new(secret.encode(), message, hashlib.sha512)
@@ -113,8 +114,8 @@ async def get_signed_cache_value(pool: AIORedis, secret: str, cache_key: str, se
 def cached_result(
     pool: AIORedis,
     prefix: str,
-    secret: Union[str, None],
-    key_name: Union[str, None] = None,
+    secret: str | None,
+    key_name: str | None = None,
     expiry_seconds: int = 120,
     serializer: SerializerProtocol = DefaultSerializer,
 ) -> Callable:

--- a/nwastdlib/debugging.py
+++ b/nwastdlib/debugging.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 SURF.
+# Copyright 2019-2025 SURF.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/nwastdlib/ex.py
+++ b/nwastdlib/ex.py
@@ -1,15 +1,15 @@
-#  Copyright 2019-2024 SURF.
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
+# Copyright 2019-2025 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#          http://www.apache.org/licenses/LICENSE-2.0
+#    http://www.apache.org/licenses/LICENSE-2.0
 #
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 """Module containing functions to deal with `Exception`s."""

--- a/nwastdlib/ex.py
+++ b/nwastdlib/ex.py
@@ -16,7 +16,6 @@
 
 
 import traceback
-from typing import Union
 
 
 def show_ex(ex: Exception, stacklimit: int | None = None) -> str:

--- a/nwastdlib/ex.py
+++ b/nwastdlib/ex.py
@@ -19,7 +19,7 @@ import traceback
 from typing import Union
 
 
-def show_ex(ex: Exception, stacklimit: Union[int, None] = None) -> str:
+def show_ex(ex: Exception, stacklimit: int | None = None) -> str:
     """Show an exception, including its class name, message and (limited) stacktrace.
 
     >>> try:

--- a/nwastdlib/f.py
+++ b/nwastdlib/f.py
@@ -12,7 +12,8 @@
 #  limitations under the License.
 #
 
-from typing import Any, Callable, TypeVar
+from typing import Any, TypeVar
+from collections.abc import Callable
 
 α = TypeVar("α")
 β = TypeVar("β")

--- a/nwastdlib/f.py
+++ b/nwastdlib/f.py
@@ -1,15 +1,15 @@
-#  Copyright 2019-2024 SURF.
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
+# Copyright 2019-2025 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#          http://www.apache.org/licenses/LICENSE-2.0
+#    http://www.apache.org/licenses/LICENSE-2.0
 #
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 from collections.abc import Callable

--- a/nwastdlib/f.py
+++ b/nwastdlib/f.py
@@ -12,8 +12,8 @@
 #  limitations under the License.
 #
 
-from typing import Any, TypeVar
 from collections.abc import Callable
+from typing import Any, TypeVar
 
 α = TypeVar("α")
 β = TypeVar("β")

--- a/nwastdlib/graphql/extensions/deprecation_checker_extension.py
+++ b/nwastdlib/graphql/extensions/deprecation_checker_extension.py
@@ -1,4 +1,4 @@
-# Copyright 2022-2024 SURF.
+# Copyright 2019-2025 SURF.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/nwastdlib/graphql/extensions/error_handler_extension.py
+++ b/nwastdlib/graphql/extensions/error_handler_extension.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 SURF.
+# Copyright 2019-2025 SURF.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/nwastdlib/graphql/extensions/error_handler_extension.py
+++ b/nwastdlib/graphql/extensions/error_handler_extension.py
@@ -14,7 +14,8 @@ from collections.abc import Collection, Generator, Iterable
 from contextvars import ContextVar
 from enum import StrEnum, auto
 from http import HTTPStatus
-from typing import Any, Callable
+from typing import Any
+from collections.abc import Callable
 
 import structlog
 from graphql import GraphQLError

--- a/nwastdlib/graphql/extensions/error_handler_extension.py
+++ b/nwastdlib/graphql/extensions/error_handler_extension.py
@@ -10,12 +10,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from collections.abc import Collection, Generator, Iterable
+from collections.abc import Callable, Collection, Generator, Iterable
 from contextvars import ContextVar
 from enum import StrEnum, auto
 from http import HTTPStatus
 from typing import Any
-from collections.abc import Callable
 
 import structlog
 from graphql import GraphQLError

--- a/nwastdlib/logging.py
+++ b/nwastdlib/logging.py
@@ -1,15 +1,15 @@
-#  Copyright 2019-2024 SURF.
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
+# Copyright 2019-2025 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#        http://www.apache.org/licenses/LICENSE-2.0
+#    http://www.apache.org/licenses/LICENSE-2.0
 #
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import logging.config
 import os

--- a/nwastdlib/logging.py
+++ b/nwastdlib/logging.py
@@ -13,7 +13,7 @@
 
 import logging.config
 import os
-from typing import Any, Union
+from typing import Any
 
 import structlog
 

--- a/nwastdlib/logging.py
+++ b/nwastdlib/logging.py
@@ -65,7 +65,7 @@ logconfig_dict = {
 }
 
 
-def initialise_logging(additional_loggers: Union[dict[str, dict[str, Any]], None] = None) -> None:
+def initialise_logging(additional_loggers: dict[str, dict[str, Any]] | None = None) -> None:
     """Initialise the StructLog logging setup.
 
     An example of the additional_loggers format:

--- a/nwastdlib/settings.py
+++ b/nwastdlib/settings.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 SURF.
+# Copyright 2019-2025 SURF.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/nwastdlib/url.py
+++ b/nwastdlib/url.py
@@ -1,15 +1,15 @@
-#  Copyright 2019-2024 SURF.
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
+# Copyright 2019-2025 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#          http://www.apache.org/licenses/LICENSE-2.0
+#    http://www.apache.org/licenses/LICENSE-2.0
 #
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 from __future__ import annotations

--- a/nwastdlib/version.py
+++ b/nwastdlib/version.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 
 from subprocess import check_output  # noqa: S404
-from typing import Union
 
 import structlog
 

--- a/nwastdlib/version.py
+++ b/nwastdlib/version.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 SURF.
+# Copyright 2019-2025 SURF.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/nwastdlib/version.py
+++ b/nwastdlib/version.py
@@ -19,7 +19,7 @@ import structlog
 logger = structlog.getLogger(__name__)
 
 
-def __getattr__(name: str) -> Union[str, None]:
+def __getattr__(name: str) -> str | None:
     """Return the GIT_COMMIT_HASH.
 
     Usage::

--- a/nwastdlib/vlans.py
+++ b/nwastdlib/vlans.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 SURF.
+# Copyright 2019-2025 SURF.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/nwastdlib/vlans.py
+++ b/nwastdlib/vlans.py
@@ -121,13 +121,11 @@ class VlanRanges(abc.Set):
 
     """
 
-    __pydantic_serializer__: ClassVar[Optional[SchemaSerializer]]  # workaround for a bug, see usage below
+    __pydantic_serializer__: ClassVar[SchemaSerializer | None]  # workaround for a bug, see usage below
 
     _vlan_ranges: tuple[range, ...]
 
-    def __init__(  # noqa: C901
-        self, val: Optional[Union[str, int, Iterable[int], Sequence[Sequence[int]]]] = None
-    ) -> None:
+    def __init__(self, val: str | int | Iterable[int] | Sequence[Sequence[int]] | None = None) -> None:  # noqa: C901
         # The idea is to bring all acceptable values to one canonical intermediate format: the `Sequence[Sequence[
         # int]]`. Where the inner sequence is either a one or two element sequence. The one element sequence
         # represents a single VLAN, the two element sequence represents a VLAN range.
@@ -226,7 +224,7 @@ class VlanRanges(abc.Set):
     def __hash__(self) -> int:
         return hash(self._vlan_ranges)
 
-    def __sub__(self, other: Union[int, AbstractSet[Any]]) -> VlanRanges:
+    def __sub__(self, other: int | AbstractSet[Any]) -> VlanRanges:
         if isinstance(other, int):
             new_set = set(self)
             new_set.remove(other)
@@ -285,7 +283,7 @@ class VlanRanges(abc.Set):
         return json_schema_resolved | schema_override
 
     @staticmethod
-    def _validate(input_value: Union[str, VlanRanges]) -> VlanRanges:
+    def _validate(input_value: str | VlanRanges) -> VlanRanges:
         if isinstance(input_value, VlanRanges):
             return input_value
         return VlanRanges(input_value)

--- a/nwastdlib/vlans.py
+++ b/nwastdlib/vlans.py
@@ -19,7 +19,7 @@ import operator
 from collections import abc
 from collections.abc import Iterable, Iterator, Sequence
 from functools import reduce, total_ordering
-from typing import AbstractSet, Any, ClassVar, Optional, Union, cast
+from typing import AbstractSet, Any, ClassVar, cast
 
 from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler
 from pydantic.json_schema import JsonSchemaValue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ Documentation = "https://workfloworchestrator.org/"
 [tool.flit.metadata.requires-extra]
 test = [
     "anyio",
+    "apache-license-check",
     "black",
     "fakeredis",
     "fastapi",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ test = [
     "fakeredis",
     "fastapi",
     "httpx",
-    "mypy==1.6.1",
+    "mypy",
     "mypy_extensions",
     "pytest",
     "pytest-cov",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ dev = [
 
 [tool.black]
 line-length = 120
-target-version = ["py39", "py310"]
+target-version = ["py311"]
 exclude = '''
 (
   /(
@@ -125,7 +125,7 @@ lint.ignore = [
 ]
 line-length = 120
 lint.select = ["B", "C", "D", "E", "F", "I", "N", "RET", "S", "T", "W"]
-target-version = "py39"
+target-version = "py311"
 
 [tool.ruff.lint.flake8-tidy-imports]
 ban-relative-imports = "all"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
     "Intended Audience :: Telecommunications Industry",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.11",
 ]
@@ -38,7 +39,7 @@ requires = [
     "structlog>=22.1.0",
 ]
 description-file = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.11,<3.14"
 
 [tool.flit.metadata.urls]
 Documentation = "https://workfloworchestrator.org/"


### PR DESCRIPTION
Bump version to 1.9.0 with changes:
* Add support for Python 3.13
* Rewrote README.md
* Used pyupgrade to use Python 3.11 syntax
* Unpinned mypy 1.6 and updated code for mypy 1.14
  * Minor type annotation change to `gather_nice_sync()` and `gather_sync()`

Other changes:
* Update license headers and add as CI check
* Run pre-commit in CI