### PR TITLE
Allow all redis-py 5.x versions

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.9.0
+current_version = 1.9.1
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/nwastdlib/__init__.py
+++ b/nwastdlib/__init__.py
@@ -13,7 +13,7 @@
 #
 """The NWA-stdlib module."""
 
-__version__ = "1.9.0"
+__version__ = "1.9.1"
 
 from nwastdlib.f import const, identity
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ requires = [
     "pydantic>=2.4.0",
     "pydantic_settings",
     "strawberry-graphql>=0.246.2",
-    "redis>=5.0, <5.1.0",
+    "redis>=5.0, <6.0",
     "structlog>=22.1.0",
 ]
 description-file = "README.md"


### PR DESCRIPTION
Bump nwa-stdlib version to 1.9.1