### PR TITLE
Improvements to cached_result

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.9.2
+current_version = 1.10.0
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/nwastdlib/__init__.py
+++ b/nwastdlib/__init__.py
@@ -13,7 +13,7 @@
 #
 """The NWA-stdlib module."""
 
-__version__ = "1.9.2"
+__version__ = "1.10.0"
 
 from nwastdlib.f import const, identity
 


### PR DESCRIPTION
- Omit 'self' argument from cache key generation -> This prevents memory addresses in generated keys when decorator is used on class methods
- Raise warnings for potentially unsafe cache key arguments
- Raise error when used on anything else than a coroutine
- Raise error when no arguments are available for cache key generation

Relates to #45 