### PR TITLE
Allow cached_result on function without args/kwargs, use func.__qualname__ in key

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.10.0
+current_version = 1.10.1
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/nwastdlib/__init__.py
+++ b/nwastdlib/__init__.py
@@ -13,7 +13,7 @@
 #
 """The NWA-stdlib module."""
 
-__version__ = "1.10.0"
+__version__ = "1.10.1"
 
 from nwastdlib.f import const, identity
 

--- a/tests/test_asyncio_cache.py
+++ b/tests/test_asyncio_cache.py
@@ -306,18 +306,8 @@ cache_key_start = f"{cache_prefix}:{version}"
             {},
             "((UUID('12345678-0000-1111-2222-0123456789ab'),), frozenset())",
         ),
+        (False, (), {}, None),
     ],
 )
 def test_generate_cache_key_suffix(skip_first, args, kwargs, expected_key):
     assert _generate_cache_key_suffix(skip_first=skip_first, args=args, kwargs=kwargs) == expected_key
-
-
-@pytest.mark.parametrize(
-    ("skip_first", "args", "kwargs", "expected_exception"),
-    [
-        (False, (), {}, ValueError),
-    ],
-)
-def test_generate_cache_key_errors(skip_first, args, kwargs, expected_exception):
-    with pytest.raises(expected_exception):
-        _generate_cache_key_suffix(skip_first=skip_first, args=args, kwargs=kwargs)


### PR DESCRIPTION
In version 1.10.0 `cached_result` was changed to not allow using it on a function without args/kwargs.

This was an oversight: it works perfectly fine thanks to the function name itself being prefixed in the cache key.

Re-instated that behavior, now using `func.__qualname__` instead of `func.__name__` to have more context in the key.


# Example

```py

class Client:

    @cached_result(...)  # without `key_name`
    async def get_foo(self):
        ...

    @cached_result(...)  # without `key_name`
    async def get_bar(self, identifier: int):
        ...
```

## Before this PR

* `Client.get_foo`: raises `ValueError: Cannot generate cache key without args/kwargs")`
* `Client.get_bar`: generates cache keys `{prefix}:{version}:get_bar:((1, ), frozenset())`

## After this PR

* `Client.get_foo`: generates cache keys `{prefix}:{version}:client.get_foo`
* `Client.get_bar`: generated cache keys `{prefix}:{version}:client.get_bar:((1, ), frozenset())`
