### PR TITLE
Allow redis-py 6.* and 7.*

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.10.5
+current_version = 1.11.0
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/nwastdlib/__init__.py
+++ b/nwastdlib/__init__.py
@@ -13,7 +13,7 @@
 #
 """The NWA-stdlib module."""
 
-__version__ = "1.10.5"
+__version__ = "1.11.0"
 
 from nwastdlib.f import const, identity
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ requires = [
     "pydantic>=2.4.0",
     "pydantic_settings",
     "strawberry-graphql>=0.246.2",
-    "redis>=5.0, <6.0",
+    "redis>=5.0, <8.0",
     "structlog>=22.1.0",
 ]
 description-file = "README.md"


### PR DESCRIPTION
https://github.com/redis/redis-py/releases/tag/v6.0.0
https://github.com/redis/redis-py/releases/tag/v7.0.0

From what I can see in the changelog, the breaking changes don't affect the redis related code in nwa-stdlib, so let's just allow it.

Bump version to 1.11.0