### PR TITLE
Fix pydevd_pycharm settrace kwargs to snake_case

### DIFF
--- a/nwastdlib/debugging.py
+++ b/nwastdlib/debugging.py
@@ -36,7 +36,7 @@ def start_debugger() -> None:
         pydevd_pycharm = __import__("pydevd_pycharm")
 
         port = nwa_settings.DEBUG_PYCHARM_PORT
-        pydevd_kwargs = {"host": "127.0.0.1", "port": port, "stdoutToServer": True, "stderrToServer": True}
+        pydevd_kwargs = {"host": "127.0.0.1", "port": port, "stdout_to_server": True, "stderr_to_server": True}
         logger.info("Connecting to pydevd server (choose 'Resume Program' in PyCharm)", pydevd_kwargs=pydevd_kwargs)
         pydevd_pycharm.settrace(**pydevd_kwargs)
         logger.info("Connected to pydevd server")

--- a/nwastdlib/vlans.py
+++ b/nwastdlib/vlans.py
@@ -159,7 +159,7 @@ class VlanRanges(abc.Set):
                 elif isinstance(val[0], abc.Sequence):
                     vlans = cast(Sequence[Sequence[int]], val)
         elif isinstance(val, abc.Iterable):
-            vlans = [[x] for x in val]  # type: ignore
+            vlans = [[x] for x in val]
         else:
             raise ValueError(f"{val} could not be converted to a {self.__class__.__name__} object.")
 


### PR DESCRIPTION
Upstream pydevd renamed stdoutToServer / stderrToServer to stdout_to_server / stderr_to_server. Update the kwargs passed to pydevd_pycharm.settrace so PyCharm remote debugging works again.