### PR TITLE
Update upper redis version to 8.0 and replace setex with set

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.11.2
+current_version = 1.12.0
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/nwastdlib/__init__.py
+++ b/nwastdlib/__init__.py
@@ -13,7 +13,7 @@
 #
 """The NWA-stdlib module."""
 
-__version__ = "1.11.2"
+__version__ = "1.12.0"
 
 from nwastdlib.f import const, identity
 

--- a/nwastdlib/asyncio_cache.py
+++ b/nwastdlib/asyncio_cache.py
@@ -75,7 +75,7 @@ def get_hmac_checksum(secret: str, message: bytes | bytearray | str) -> str:
 async def set_cache_value(
     pool: AIORedis, cache_key: str, value: Any, expiry_seconds: int, serializer: SerializerProtocol
 ) -> None:
-    await pool.setex(cache_key, expiry_seconds, serializer.serialize(value))
+    await pool.set(cache_key, serializer.serialize(value), ex=expiry_seconds)
 
 
 async def get_cache_value(pool: AIORedis, cache_key: str, serializer: SerializerProtocol) -> Any:
@@ -89,9 +89,8 @@ async def set_signed_cache_value(
     pickled_value = serializer.serialize(value)
     checksum = get_hmac_checksum(secret, pickled_value)
     pipeline = pool.pipeline()
-    pipeline.setex(cache_key, expiry_seconds, pickled_value).setex(
-        f"{cache_key}-checksum", expiry_seconds, checksum.encode()
-    )
+    pipeline.set(cache_key, pickled_value, ex=expiry_seconds)
+    pipeline.set(f"{cache_key}-checksum", checksum.encode(), ex=expiry_seconds)
     result_set_cache_value, result_set_cache_checksum = await pipeline.execute()
     if not result_set_cache_value or not result_set_cache_checksum:
         logger.warning(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ requires = [
     "pydantic>=2.4.0",
     "pydantic_settings",
     "strawberry-graphql>=0.246.2",
-    "redis>=5.0, <8.0",
+    "redis>=5.0, <9.0",
     "structlog>=22.1.0",
 ]
 description-file = "README.md"

--- a/tests/test_asyncio_cache.py
+++ b/tests/test_asyncio_cache.py
@@ -111,7 +111,7 @@ async def test_cache_decorator_wrong_checksum():
     value = 1
 
     # patch the checksum value
-    await redis.setex(f"test-suite:{python_major}.{python_minor}:keyname-checksum", 120, "123456789")
+    await redis.set(f"test-suite:{python_major}.{python_minor}:keyname-checksum", "123456789", ex=120)
 
     # A new call should return 1: due to the checksum error the function is called again
     result = await slow_function()
@@ -135,7 +135,7 @@ async def test_cache_decorator_wrong_data():
     value = 1
 
     # patch the cache value
-    await redis.setex(f"test-suite:{python_major}.{python_minor}:keyname", 120, b"faked_data")
+    await redis.set(f"test-suite:{python_major}.{python_minor}:keyname", b"faked_data", ex=120)
 
     # A new call should return 1: due to the checksum error the function is called again
     result = await slow_function()


### PR DESCRIPTION
Update upper redis version to 8.0 and replace setex (deprecated in 8.0) with set. This is backward compatible with older versions.